### PR TITLE
edit/biosynthesis: Add Graspeptide RiPP class

### DIFF
--- a/submission/edit/forms/biosynthesis.py
+++ b/submission/edit/forms/biosynthesis.py
@@ -161,6 +161,7 @@ class RibosomalForm(Form):
             "Dikaritin",
             "Epipeptide",
             "Glycocin",
+            "Graspeptide",
             "Guanidinotide",
             "Head-to-tail cyclized peptide",
             "Lanthipeptide",


### PR DESCRIPTION
Technically it should replace microviridin, but let's keep it for backwards compatibility for now